### PR TITLE
Replace observer queries with statistics collection queries on watch

### DIFF
--- a/Duffy WatchKit Extension/ExtensionDelegate.swift
+++ b/Duffy WatchKit Extension/ExtensionDelegate.swift
@@ -22,9 +22,7 @@ class ExtensionDelegate: NSObject, WKExtensionDelegate, WCSessionServiceDelegate
     
     func applicationDidFinishLaunching() {
         LoggingService.log("App did finish launching")
-        // Perform any final initialization of your application.
-        HealthKitService.getInstance().initializeBackgroundQueries()
-        HealthKitService.getInstance().setEventDelegate(self)
+        startHealthKitObservers()
         NotificationService.maybeAskForNotificationPermission(self)
         if CoreMotionService.getInstance().shouldAskPermission() {
             CoreMotionService.getInstance().askForPermission()
@@ -46,13 +44,15 @@ class ExtensionDelegate: NSObject, WKExtensionDelegate, WCSessionServiceDelegate
     }
     
     func applicationDidBecomeActive() {
-        LoggingService.log("App did become active")
+        LoggingService.log("App did become active - stop observers")
+        stopHealthKitObservers()
     }
 
     func applicationWillResignActive() {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, etc.
-        LoggingService.log("App will resign active")
+        LoggingService.log("App will resign active - restart observers")
+        startHealthKitObservers()
     }
 
     func complicationUpdateRequested(_ complicationData : [String : AnyObject])
@@ -160,5 +160,14 @@ class ExtensionDelegate: NSObject, WKExtensionDelegate, WCSessionServiceDelegate
                                 withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
 
         completionHandler(UNNotificationPresentationOptions.alert)
+    }
+    
+    private func startHealthKitObservers() {
+        HealthKitService.getInstance().initializeBackgroundQueries()
+        HealthKitService.getInstance().setEventDelegate(self)
+    }
+    
+    private func stopHealthKitObservers() {
+        HealthKitService.getInstance().stopBackgroundQueries()
     }
 }

--- a/Duffy WatchKit Extension/ExtensionDelegate.swift
+++ b/Duffy WatchKit Extension/ExtensionDelegate.swift
@@ -174,7 +174,7 @@ class ExtensionDelegate: NSObject, WKExtensionDelegate, WCSessionServiceDelegate
     }
     
     private func startHealthKitBackgroundQueries() {
-        HealthKitService.getInstance().initializeBackgroundQueries()
         HealthKitService.getInstance().setEventDelegate(self)
+        HealthKitService.getInstance().initializeBackgroundQueries()
     }
 }

--- a/Duffy WatchKit Extension/ExtensionDelegate.swift
+++ b/Duffy WatchKit Extension/ExtensionDelegate.swift
@@ -22,7 +22,7 @@ class ExtensionDelegate: NSObject, WKExtensionDelegate, WCSessionServiceDelegate
     
     func applicationDidFinishLaunching() {
         LoggingService.log("App did finish launching")
-        startHealthKitObservers()
+        startHealthKitBackgroundQueries()
         NotificationService.maybeAskForNotificationPermission(self)
         if CoreMotionService.getInstance().shouldAskPermission() {
             CoreMotionService.getInstance().askForPermission()
@@ -36,17 +36,11 @@ class ExtensionDelegate: NSObject, WKExtensionDelegate, WCSessionServiceDelegate
     }
     
     func applicationWillEnterForeground() {
-        LoggingService.log("App will enter foreground - stop observers")
-        stopHealthKitObservers()
+        LoggingService.log("App will enter foreground")
         if WKExtension.shared().isApplicationRunningInDock,
             let c = WKExtension.shared().rootInterfaceController as? InterfaceController {
             c.refreshPressed()
         }
-    }
-    
-    func applicationDidEnterBackground() {
-        LoggingService.log("App did enter background  - restart observers")
-        startHealthKitObservers()
     }
     
     func applicationDidBecomeActive() {
@@ -166,12 +160,8 @@ class ExtensionDelegate: NSObject, WKExtensionDelegate, WCSessionServiceDelegate
         completionHandler(UNNotificationPresentationOptions.alert)
     }
     
-    private func startHealthKitObservers() {
+    private func startHealthKitBackgroundQueries() {
         HealthKitService.getInstance().initializeBackgroundQueries()
         HealthKitService.getInstance().setEventDelegate(self)
-    }
-    
-    private func stopHealthKitObservers() {
-        HealthKitService.getInstance().stopBackgroundQueries()
     }
 }

--- a/Duffy WatchKit Extension/ExtensionDelegate.swift
+++ b/Duffy WatchKit Extension/ExtensionDelegate.swift
@@ -9,6 +9,7 @@
 import WatchKit
 import DuffyWatchFramework
 import UserNotifications
+import HealthKit
 
 class ExtensionDelegate: NSObject, WKExtensionDelegate, WCSessionServiceDelegate, HealthEventDelegate, UNUserNotificationCenterDelegate
 {
@@ -37,9 +38,13 @@ class ExtensionDelegate: NSObject, WKExtensionDelegate, WCSessionServiceDelegate
     
     func applicationWillEnterForeground() {
         LoggingService.log("App will enter foreground")
-        if WKExtension.shared().isApplicationRunningInDock,
-            let c = WKExtension.shared().rootInterfaceController as? InterfaceController {
-            c.refreshPressed()
+        
+        if let c = WKExtension.shared().rootInterfaceController as? InterfaceController {
+            if WKExtension.shared().isApplicationRunningInDock {
+                c.refreshPressed()
+            }
+            
+            c.subscribeToHealthKitUpdates()
         }
     }
     
@@ -51,6 +56,14 @@ class ExtensionDelegate: NSObject, WKExtensionDelegate, WCSessionServiceDelegate
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, etc.
         LoggingService.log("App will resign active")
+    }
+    
+    func applicationDidEnterBackground() {
+        LoggingService.log("App will enter background")
+        
+        if let c = WKExtension.shared().rootInterfaceController as? InterfaceController {
+            c.unsubscribeToHealthKitUpdates()
+        }
     }
 
     func complicationUpdateRequested(_ complicationData : [String : AnyObject])

--- a/Duffy WatchKit Extension/ExtensionDelegate.swift
+++ b/Duffy WatchKit Extension/ExtensionDelegate.swift
@@ -36,23 +36,27 @@ class ExtensionDelegate: NSObject, WKExtensionDelegate, WCSessionServiceDelegate
     }
     
     func applicationWillEnterForeground() {
-        LoggingService.log("App will enter foreground")
+        LoggingService.log("App will enter foreground - stop observers")
+        stopHealthKitObservers()
         if WKExtension.shared().isApplicationRunningInDock,
             let c = WKExtension.shared().rootInterfaceController as? InterfaceController {
             c.refreshPressed()
         }
     }
     
+    func applicationDidEnterBackground() {
+        LoggingService.log("App did enter background  - restart observers")
+        startHealthKitObservers()
+    }
+    
     func applicationDidBecomeActive() {
-        LoggingService.log("App did become active - stop observers")
-        stopHealthKitObservers()
+        LoggingService.log("App did become active")
     }
 
     func applicationWillResignActive() {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, etc.
-        LoggingService.log("App will resign active - restart observers")
-        startHealthKitObservers()
+        LoggingService.log("App will resign active")
     }
 
     func complicationUpdateRequested(_ complicationData : [String : AnyObject])

--- a/Duffy WatchKit Extension/InterfaceController.swift
+++ b/Duffy WatchKit Extension/InterfaceController.swift
@@ -269,6 +269,7 @@ class InterfaceController: WKInterfaceController
         }
         
         timer = nil
+        isQueryInProgress = false
     }
     
     private func maybeTurnOverComplicationDate() {

--- a/Duffy WatchKit Extension/InterfaceController.swift
+++ b/Duffy WatchKit Extension/InterfaceController.swift
@@ -234,7 +234,10 @@ class InterfaceController: WKInterfaceController
     }
     
     func subscribeToHealthKitUpdates() {
-        LoggingService.log("Subscribe to HK updates")
+        if let healthDelegate = WKExtension.shared().delegate as? ExtensionDelegate {
+            HealthKitService.getInstance().setEventDelegate(healthDelegate)
+        }
+        HealthKitService.getInstance().initializeBackgroundQueries()
         
         HealthKitService.getInstance().subscribe(to: HKQuantityTypeIdentifier.stepCount, on: {
             DispatchQueue.main.async {
@@ -256,7 +259,6 @@ class InterfaceController: WKInterfaceController
     }
     
     func unsubscribeToHealthKitUpdates() {
-        LoggingService.log("Unsubscribe from HK updates")
         HealthKitService.getInstance().unsubscribe(from: HKQuantityTypeIdentifier.stepCount)
         isQueryInProgress = false
     }

--- a/Duffy.xcodeproj/project.pbxproj
+++ b/Duffy.xcodeproj/project.pbxproj
@@ -1136,7 +1136,7 @@
 				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
 				CODE_SIGN_ENTITLEMENTS = "Duffy WatchKit Extension/Duffy WatchKit Extension.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 22;
+				CURRENT_PROJECT_VERSION = 23;
 				INFOPLIST_FILE = "Duffy WatchKit Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				MARKETING_VERSION = 3.4.2;
@@ -1157,7 +1157,7 @@
 				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
 				CODE_SIGN_ENTITLEMENTS = "Duffy WatchKit Extension/Duffy WatchKit Extension.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 22;
+				CURRENT_PROJECT_VERSION = 23;
 				INFOPLIST_FILE = "Duffy WatchKit Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				MARKETING_VERSION = 3.4.2;
@@ -1177,7 +1177,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 22;
+				CURRENT_PROJECT_VERSION = 23;
 				IBSC_MODULE = Duffy_WatchKit_Extension;
 				INFOPLIST_FILE = "Duffy WatchKit App/Info.plist";
 				MARKETING_VERSION = 3.4.2;
@@ -1197,7 +1197,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 22;
+				CURRENT_PROJECT_VERSION = 23;
 				IBSC_MODULE = Duffy_WatchKit_Extension;
 				INFOPLIST_FILE = "Duffy WatchKit App/Info.plist";
 				MARKETING_VERSION = 3.4.2;
@@ -1218,7 +1218,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Duffy/Duffy.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 22;
+				CURRENT_PROJECT_VERSION = 23;
 				DEVELOPMENT_TEAM = 2ZMUDMBY38;
 				INFOPLIST_FILE = Duffy/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
@@ -1237,7 +1237,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Duffy/Duffy.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 22;
+				CURRENT_PROJECT_VERSION = 23;
 				DEVELOPMENT_TEAM = 2ZMUDMBY38;
 				INFOPLIST_FILE = Duffy/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
@@ -1362,7 +1362,7 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CODE_SIGN_ENTITLEMENTS = DuffyToday/DuffyToday.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 22;
+				CURRENT_PROJECT_VERSION = 23;
 				DEVELOPMENT_TEAM = 2ZMUDMBY38;
 				INFOPLIST_FILE = DuffyToday/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
@@ -1383,7 +1383,7 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CODE_SIGN_ENTITLEMENTS = DuffyToday/DuffyToday.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 22;
+				CURRENT_PROJECT_VERSION = 23;
 				DEVELOPMENT_TEAM = 2ZMUDMBY38;
 				INFOPLIST_FILE = DuffyToday/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;

--- a/Duffy.xcodeproj/project.pbxproj
+++ b/Duffy.xcodeproj/project.pbxproj
@@ -1136,7 +1136,7 @@
 				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
 				CODE_SIGN_ENTITLEMENTS = "Duffy WatchKit Extension/Duffy WatchKit Extension.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 20;
 				INFOPLIST_FILE = "Duffy WatchKit Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				MARKETING_VERSION = 3.4.2;
@@ -1157,7 +1157,7 @@
 				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
 				CODE_SIGN_ENTITLEMENTS = "Duffy WatchKit Extension/Duffy WatchKit Extension.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 20;
 				INFOPLIST_FILE = "Duffy WatchKit Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				MARKETING_VERSION = 3.4.2;
@@ -1177,7 +1177,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 20;
 				IBSC_MODULE = Duffy_WatchKit_Extension;
 				INFOPLIST_FILE = "Duffy WatchKit App/Info.plist";
 				MARKETING_VERSION = 3.4.2;
@@ -1197,7 +1197,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 20;
 				IBSC_MODULE = Duffy_WatchKit_Extension;
 				INFOPLIST_FILE = "Duffy WatchKit App/Info.plist";
 				MARKETING_VERSION = 3.4.2;
@@ -1218,7 +1218,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Duffy/Duffy.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 20;
 				DEVELOPMENT_TEAM = 2ZMUDMBY38;
 				INFOPLIST_FILE = Duffy/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
@@ -1237,7 +1237,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Duffy/Duffy.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 20;
 				DEVELOPMENT_TEAM = 2ZMUDMBY38;
 				INFOPLIST_FILE = Duffy/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
@@ -1362,7 +1362,7 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CODE_SIGN_ENTITLEMENTS = DuffyToday/DuffyToday.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 20;
 				DEVELOPMENT_TEAM = 2ZMUDMBY38;
 				INFOPLIST_FILE = DuffyToday/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
@@ -1383,7 +1383,7 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CODE_SIGN_ENTITLEMENTS = DuffyToday/DuffyToday.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 19;
+				CURRENT_PROJECT_VERSION = 20;
 				DEVELOPMENT_TEAM = 2ZMUDMBY38;
 				INFOPLIST_FILE = DuffyToday/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;

--- a/Duffy.xcodeproj/project.pbxproj
+++ b/Duffy.xcodeproj/project.pbxproj
@@ -1136,7 +1136,7 @@
 				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
 				CODE_SIGN_ENTITLEMENTS = "Duffy WatchKit Extension/Duffy WatchKit Extension.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 19;
 				INFOPLIST_FILE = "Duffy WatchKit Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				MARKETING_VERSION = 3.4.2;
@@ -1157,7 +1157,7 @@
 				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
 				CODE_SIGN_ENTITLEMENTS = "Duffy WatchKit Extension/Duffy WatchKit Extension.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 19;
 				INFOPLIST_FILE = "Duffy WatchKit Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				MARKETING_VERSION = 3.4.2;
@@ -1177,7 +1177,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 19;
 				IBSC_MODULE = Duffy_WatchKit_Extension;
 				INFOPLIST_FILE = "Duffy WatchKit App/Info.plist";
 				MARKETING_VERSION = 3.4.2;
@@ -1197,7 +1197,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 19;
 				IBSC_MODULE = Duffy_WatchKit_Extension;
 				INFOPLIST_FILE = "Duffy WatchKit App/Info.plist";
 				MARKETING_VERSION = 3.4.2;
@@ -1218,7 +1218,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Duffy/Duffy.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 19;
 				DEVELOPMENT_TEAM = 2ZMUDMBY38;
 				INFOPLIST_FILE = Duffy/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
@@ -1237,7 +1237,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Duffy/Duffy.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 19;
 				DEVELOPMENT_TEAM = 2ZMUDMBY38;
 				INFOPLIST_FILE = Duffy/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
@@ -1362,7 +1362,7 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CODE_SIGN_ENTITLEMENTS = DuffyToday/DuffyToday.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 19;
 				DEVELOPMENT_TEAM = 2ZMUDMBY38;
 				INFOPLIST_FILE = DuffyToday/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
@@ -1383,7 +1383,7 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CODE_SIGN_ENTITLEMENTS = DuffyToday/DuffyToday.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 19;
 				DEVELOPMENT_TEAM = 2ZMUDMBY38;
 				INFOPLIST_FILE = DuffyToday/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;

--- a/Duffy.xcodeproj/project.pbxproj
+++ b/Duffy.xcodeproj/project.pbxproj
@@ -1136,7 +1136,7 @@
 				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
 				CODE_SIGN_ENTITLEMENTS = "Duffy WatchKit Extension/Duffy WatchKit Extension.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				INFOPLIST_FILE = "Duffy WatchKit Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				MARKETING_VERSION = 3.4.2;
@@ -1157,7 +1157,7 @@
 				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
 				CODE_SIGN_ENTITLEMENTS = "Duffy WatchKit Extension/Duffy WatchKit Extension.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				INFOPLIST_FILE = "Duffy WatchKit Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				MARKETING_VERSION = 3.4.2;
@@ -1177,7 +1177,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				IBSC_MODULE = Duffy_WatchKit_Extension;
 				INFOPLIST_FILE = "Duffy WatchKit App/Info.plist";
 				MARKETING_VERSION = 3.4.2;
@@ -1197,7 +1197,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				IBSC_MODULE = Duffy_WatchKit_Extension;
 				INFOPLIST_FILE = "Duffy WatchKit App/Info.plist";
 				MARKETING_VERSION = 3.4.2;
@@ -1218,7 +1218,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Duffy/Duffy.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				DEVELOPMENT_TEAM = 2ZMUDMBY38;
 				INFOPLIST_FILE = Duffy/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
@@ -1237,7 +1237,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Duffy/Duffy.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				DEVELOPMENT_TEAM = 2ZMUDMBY38;
 				INFOPLIST_FILE = Duffy/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
@@ -1362,7 +1362,7 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CODE_SIGN_ENTITLEMENTS = DuffyToday/DuffyToday.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				DEVELOPMENT_TEAM = 2ZMUDMBY38;
 				INFOPLIST_FILE = DuffyToday/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
@@ -1383,7 +1383,7 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CODE_SIGN_ENTITLEMENTS = DuffyToday/DuffyToday.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				DEVELOPMENT_TEAM = 2ZMUDMBY38;
 				INFOPLIST_FILE = DuffyToday/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;

--- a/Duffy.xcodeproj/project.pbxproj
+++ b/Duffy.xcodeproj/project.pbxproj
@@ -1136,7 +1136,7 @@
 				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
 				CODE_SIGN_ENTITLEMENTS = "Duffy WatchKit Extension/Duffy WatchKit Extension.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 17;
+				CURRENT_PROJECT_VERSION = 18;
 				INFOPLIST_FILE = "Duffy WatchKit Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				MARKETING_VERSION = 3.4.2;
@@ -1157,7 +1157,7 @@
 				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
 				CODE_SIGN_ENTITLEMENTS = "Duffy WatchKit Extension/Duffy WatchKit Extension.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 17;
+				CURRENT_PROJECT_VERSION = 18;
 				INFOPLIST_FILE = "Duffy WatchKit Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				MARKETING_VERSION = 3.4.2;
@@ -1177,7 +1177,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 17;
+				CURRENT_PROJECT_VERSION = 18;
 				IBSC_MODULE = Duffy_WatchKit_Extension;
 				INFOPLIST_FILE = "Duffy WatchKit App/Info.plist";
 				MARKETING_VERSION = 3.4.2;
@@ -1197,7 +1197,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 17;
+				CURRENT_PROJECT_VERSION = 18;
 				IBSC_MODULE = Duffy_WatchKit_Extension;
 				INFOPLIST_FILE = "Duffy WatchKit App/Info.plist";
 				MARKETING_VERSION = 3.4.2;
@@ -1218,7 +1218,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Duffy/Duffy.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 17;
+				CURRENT_PROJECT_VERSION = 18;
 				DEVELOPMENT_TEAM = 2ZMUDMBY38;
 				INFOPLIST_FILE = Duffy/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
@@ -1237,7 +1237,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Duffy/Duffy.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 17;
+				CURRENT_PROJECT_VERSION = 18;
 				DEVELOPMENT_TEAM = 2ZMUDMBY38;
 				INFOPLIST_FILE = Duffy/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
@@ -1362,7 +1362,7 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CODE_SIGN_ENTITLEMENTS = DuffyToday/DuffyToday.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 17;
+				CURRENT_PROJECT_VERSION = 18;
 				DEVELOPMENT_TEAM = 2ZMUDMBY38;
 				INFOPLIST_FILE = DuffyToday/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
@@ -1383,7 +1383,7 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CODE_SIGN_ENTITLEMENTS = DuffyToday/DuffyToday.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 17;
+				CURRENT_PROJECT_VERSION = 18;
 				DEVELOPMENT_TEAM = 2ZMUDMBY38;
 				INFOPLIST_FILE = DuffyToday/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;

--- a/Duffy.xcodeproj/project.pbxproj
+++ b/Duffy.xcodeproj/project.pbxproj
@@ -1136,7 +1136,7 @@
 				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
 				CODE_SIGN_ENTITLEMENTS = "Duffy WatchKit Extension/Duffy WatchKit Extension.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				INFOPLIST_FILE = "Duffy WatchKit Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				MARKETING_VERSION = 3.4.2;
@@ -1157,7 +1157,7 @@
 				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
 				CODE_SIGN_ENTITLEMENTS = "Duffy WatchKit Extension/Duffy WatchKit Extension.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				INFOPLIST_FILE = "Duffy WatchKit Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				MARKETING_VERSION = 3.4.2;
@@ -1177,7 +1177,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				IBSC_MODULE = Duffy_WatchKit_Extension;
 				INFOPLIST_FILE = "Duffy WatchKit App/Info.plist";
 				MARKETING_VERSION = 3.4.2;
@@ -1197,7 +1197,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				IBSC_MODULE = Duffy_WatchKit_Extension;
 				INFOPLIST_FILE = "Duffy WatchKit App/Info.plist";
 				MARKETING_VERSION = 3.4.2;
@@ -1218,7 +1218,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Duffy/Duffy.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				DEVELOPMENT_TEAM = 2ZMUDMBY38;
 				INFOPLIST_FILE = Duffy/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
@@ -1237,7 +1237,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Duffy/Duffy.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				DEVELOPMENT_TEAM = 2ZMUDMBY38;
 				INFOPLIST_FILE = Duffy/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
@@ -1362,7 +1362,7 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CODE_SIGN_ENTITLEMENTS = DuffyToday/DuffyToday.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				DEVELOPMENT_TEAM = 2ZMUDMBY38;
 				INFOPLIST_FILE = DuffyToday/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
@@ -1383,7 +1383,7 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CODE_SIGN_ENTITLEMENTS = DuffyToday/DuffyToday.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 21;
+				CURRENT_PROJECT_VERSION = 22;
 				DEVELOPMENT_TEAM = 2ZMUDMBY38;
 				INFOPLIST_FILE = DuffyToday/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;

--- a/DuffyFramework/HealthKitService.swift
+++ b/DuffyFramework/HealthKitService.swift
@@ -443,6 +443,16 @@ open class HealthKitService
                     WCSessionService.getInstance().updateWatchFaceComplication(["stepsdataresponse" : HealthCache.getStepsDataFromCache() as AnyObject])
                 }
                 
+                if todaysSteps >= HealthCache.getStepsDailyGoal(),
+                    NotificationService.convertDayToKey(startDate) == NotificationService.convertDayToKey(Date())
+                {
+                    HealthCache.incrementGoalReachedCounter()
+                    
+                    if let del = self?.eventDelegate {
+                        del.dailyStepsGoalWasReached()
+                    }
+                }
+                
                 if let sampleId = query.objectType?.identifier,
                     let subscriber = self?.subscribers[sampleId]
                 {

--- a/DuffyFramework/HealthKitService.swift
+++ b/DuffyFramework/HealthKitService.swift
@@ -323,6 +323,7 @@ open class HealthKitService
         guard let healthStore = healthStore else { return }
         observerQueries.forEach({
             healthStore.stop($1)
+            LoggingService.log("Stopped observer query")
         })
         observerQueries.removeAll()
     }

--- a/DuffyFramework/HealthKitService.swift
+++ b/DuffyFramework/HealthKitService.swift
@@ -15,6 +15,7 @@ open class HealthKitService
     private var healthStore: HKHealthStore?
     private var eventDelegate: HealthEventDelegate?
     private var observerQueries = [String : HKObserverQuery]()
+    private var statisticsQueries = [String : HKStatisticsCollectionQuery]()
     private var subscribers = [String : HealthKitSubscriber]()
     public private(set) var shouldRestartObservers: Bool = false
 
@@ -290,24 +291,22 @@ open class HealthKitService
     
     open func initializeBackgroundQueries()
     {
-        if let store = healthStore
+        if let store = healthStore, let stepsType = HKQuantityType.quantityType(forIdentifier: .stepCount)
         {
-            LoggingService.log("App is starting observers")
-            
             DispatchQueue.main.async {
                 self.shouldRestartObservers = false
             }
             
-            if let stepsType = HKQuantityType.quantityType(forIdentifier: .stepCount)
-            {
-                let key = "steps"
-                let query = createObserverQuery(key: key, sampleType: stepsType, store: store)
-                observerQueries[key] = query
-                store.execute(query)
-                enableBackgroundQueryOnPhone(for: stepsType, at: .hourly, in: store)
-            }
+            let stepsKey = "steps"
             
             #if os(iOS)
+                LoggingService.log("App is starting observers")
+            
+                let query = createObserverQuery(key: stepsKey, sampleType: stepsType, store: store)
+                observerQueries[stepsKey] = query
+                store.execute(query)
+                enableBackgroundQueryOnPhone(for: stepsType, at: .hourly, in: store)
+
                 if let activeType = HKQuantityType.quantityType(forIdentifier: .activeEnergyBurned) {
                     let key = "activeEnergy"
                     let query = createObserverQuery(key: key, sampleType: activeType, store: store)
@@ -315,17 +314,29 @@ open class HealthKitService
                     store.execute(query)
                     enableBackgroundQueryOnPhone(for: activeType, at: .immediate, in: store)
                 }
+            #elseif os(watchOS)
+                LoggingService.log("App is starting stats queries")
+            
+                if let statsQuery = createUpdatingStatisticsQuery(key: stepsKey, quantityType: stepsType, store: store) {
+                    statisticsQueries[stepsKey] = statsQuery
+                    store.execute(statsQuery)
+                }
             #endif
         }
     }
     
     open func stopBackgroundQueries() {
         guard let healthStore = healthStore else { return }
+        
         observerQueries.forEach({
             healthStore.stop($1)
-            LoggingService.log("Stopped observer query")
         })
         observerQueries.removeAll()
+        
+        statisticsQueries.forEach({
+            healthStore.stop($1)
+        })
+        statisticsQueries.removeAll()
     }
     
     private func createObserverQuery(key: String, sampleType: HKSampleType, store: HKHealthStore) -> HKObserverQuery
@@ -388,6 +399,76 @@ open class HealthKitService
                 }
             })
         #endif
+    }
+    
+    private func createUpdatingStatisticsQuery(key: String, quantityType: HKQuantityType, store: HKHealthStore) -> HKStatisticsCollectionQuery?
+    {
+        if let oldQuery = statisticsQueries.removeValue(forKey: key) {
+            store.stop(oldQuery)
+        }
+        
+        let today = getQueryDate(from: Date())
+        guard let sinceDate = today else { return nil }
+        
+        let sinceDatePredicate = HKQuery.predicateForSamples(withStart: sinceDate, end: nil, options: .strictEndDate)
+        var interval = DateComponents()
+        interval.day = 1
+        
+        let statsQuery = HKStatisticsCollectionQuery(quantityType: quantityType,
+                                                quantitySamplePredicate: sinceDatePredicate,
+                                                options: .cumulativeSum,
+                                                anchorDate: sinceDate,
+                                                intervalComponents: interval)
+        
+        let resultsHandler: (HKStatisticsCollectionQuery, HKStatisticsCollection?, Error?) -> Void = { [weak self] query, results, error in
+            if let results = results,
+                error == nil,
+                let startDate = self?.getQueryDate(from: Date()),
+                let endDate = self?.getQueryEndDate(fromStartDate: startDate)
+            {
+                var todaysSteps: Int = 0
+                
+                results.enumerateStatistics(from: startDate, to: endDate) {
+                    statistics, stop in
+                    
+                    if let quantity = statistics.sumQuantity() {
+                        todaysSteps += Int(quantity.doubleValue(for: HKUnit.count()))
+                    }
+                }
+                
+                LoggingService.log(String(format: "Steps retrieved by %@ stats query", key), with: String(format: "%d", todaysSteps))
+                
+                if (HealthCache.saveStepsToCache(todaysSteps, forDay: startDate)) {
+                    LoggingService.log(String(format: "updateWatchFaceComplication from %@ stats query", key), with: String(format: "%d", todaysSteps))
+                    WCSessionService.getInstance().updateWatchFaceComplication(["stepsdataresponse" : HealthCache.getStepsDataFromCache() as AnyObject])
+                }
+                
+                if let sampleId = query.objectType?.identifier,
+                    let subscriber = self?.subscribers[sampleId]
+                {
+                    subscriber.updateHandler()
+                }
+            }
+            else if let error = error
+            {
+                LoggingService.log(error: error)
+                
+                let nsUpdateError = error as NSError
+                //Error code 5 is 'authorization not determined'. Permission hasn't been granted yet
+                if nsUpdateError.code == 5 && nsUpdateError.domain == "com.apple.healthkit" {
+                    DispatchQueue.main.async {
+                        self?.shouldRestartObservers = true
+                    }
+                }
+            }
+        }
+        
+        statsQuery.initialResultsHandler = resultsHandler
+        statsQuery.statisticsUpdateHandler = { query, stats, results, error in
+            resultsHandler(query, results, error)
+        }
+        
+        return statsQuery
     }
     
     open func cacheTodaysStepsAndUpdateComplication(_ onComplete: ((_ success: Bool) -> (Void))?)

--- a/DuffyFramework/HealthKitService.swift
+++ b/DuffyFramework/HealthKitService.swift
@@ -319,6 +319,14 @@ open class HealthKitService
         }
     }
     
+    open func stopBackgroundQueries() {
+        guard let healthStore = healthStore else { return }
+        observerQueries.forEach({
+            healthStore.stop($1)
+        })
+        observerQueries.removeAll()
+    }
+    
     private func createObserverQuery(key: String, sampleType: HKSampleType, store: HKHealthStore) -> HKObserverQuery
     {
         if let oldQuery = observerQueries[key]

--- a/DuffyFramework/HealthKitService.swift
+++ b/DuffyFramework/HealthKitService.swift
@@ -410,12 +410,11 @@ open class HealthKitService
         let today = getQueryDate(from: Date())
         guard let sinceDate = today else { return nil }
         
-        let sinceDatePredicate = HKQuery.predicateForSamples(withStart: sinceDate, end: nil, options: .strictEndDate)
         var interval = DateComponents()
         interval.day = 1
         
         let statsQuery = HKStatisticsCollectionQuery(quantityType: quantityType,
-                                                quantitySamplePredicate: sinceDatePredicate,
+                                                quantitySamplePredicate: nil,
                                                 options: .cumulativeSum,
                                                 anchorDate: sinceDate,
                                                 intervalComponents: interval)

--- a/DuffyFramework/WCSessionService.swift
+++ b/DuffyFramework/WCSessionService.swift
@@ -106,16 +106,6 @@ open class WCSessionService : NSObject, WCSessionDelegate
                         WCSession.default.transferCurrentComplicationUserInfo(complicationData)
                         let remaining = WCSession.default.remainingComplicationUserInfoTransfers
                         LoggingService.log("Requested to send data to watch, remaining transfers", with: remaining.description)
-                        
-                        if Constants.isDebugMode {
-                            //Log transfer status
-                            var outstandingLog = ""
-                            WCSession.default.outstandingUserInfoTransfers.forEach({
-                                outstandingLog += $0.isCurrentComplicationInfo ? "Complication Info: " : "Regular Info: "
-                                outstandingLog += $0.isTransferring ? "Transferring | " : "Pending | "
-                            })
-                            LoggingService.log("Trnasfer status", with: outstandingLog)
-                        }
                     } else {
                         LoggingService.log("Complication NOT enabled", at: .debug)
                     }

--- a/DuffyFramework/WCSessionService.swift
+++ b/DuffyFramework/WCSessionService.swift
@@ -103,9 +103,19 @@ open class WCSessionService : NSObject, WCSessionDelegate
                 if WCSession.default.activationState == .activated
                 {
                     if WCSession.default.isComplicationEnabled {
-                        let remaining = WCSession.default.remainingComplicationUserInfoTransfers
-                        LoggingService.log("Send data to watch, remaining transfers", with: remaining.description)
                         WCSession.default.transferCurrentComplicationUserInfo(complicationData)
+                        let remaining = WCSession.default.remainingComplicationUserInfoTransfers
+                        LoggingService.log("Requested to send data to watch, remaining transfers", with: remaining.description)
+                        
+                        if Constants.isDebugMode {
+                            //Log transfer status
+                            var outstandingLog = ""
+                            WCSession.default.outstandingUserInfoTransfers.forEach({
+                                outstandingLog += $0.isCurrentComplicationInfo ? "Complication Info: " : "Regular Info: "
+                                outstandingLog += $0.isTransferring ? "Transferring | " : "Pending | "
+                            })
+                            LoggingService.log("Trnasfer status", with: outstandingLog)
+                        }
                     } else {
                         LoggingService.log("Complication NOT enabled", at: .debug)
                     }


### PR DESCRIPTION
After recording a run workout there are hundreds of samples that get processed by the observer when the watch app is opened and this causes performance issues. This should prevent that.